### PR TITLE
feat: remove forced nullability + overload ValueOrPromise.all

### DIFF
--- a/.changeset/dirty-bees-deny.md
+++ b/.changeset/dirty-bees-deny.md
@@ -1,0 +1,5 @@
+---
+'value-or-promise': patch
+---
+
+fix(types): do not make results nullable

--- a/src/ValueOrPromise.ts
+++ b/src/ValueOrPromise.ts
@@ -6,7 +6,7 @@ function isPromiseLike<T>(object: unknown): object is PromiseLike<T> {
 
 interface FulfilledState<T> {
   status: 'fulfilled';
-  value: T | undefined | null;
+  value: T;
 }
 
 interface RejectedState {
@@ -28,8 +28,8 @@ const defaultOnRejectedFn = (reason: unknown) => {
 export class ValueOrPromise<T> {
   private readonly state: State<T>;
 
-  constructor(executor: () => T | PromiseLike<T> | undefined | null) {
-    let value: T | PromiseLike<T> | undefined | null;
+  constructor(executor: () => T | PromiseLike<T>) {
+    let value: T | PromiseLike<T>;
 
     try {
       value = executor();
@@ -106,10 +106,28 @@ export class ValueOrPromise<T> {
     return state.value;
   }
 
+  // prettier-ignore
+  public static all<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(values: readonly [ValueOrPromise<T1>, ValueOrPromise<T2>, ValueOrPromise<T3>, ValueOrPromise<T4>, ValueOrPromise<T5>, ValueOrPromise<T6>, ValueOrPromise<T7>, ValueOrPromise<T8>, ValueOrPromise<T9>, ValueOrPromise<T10>]): ValueOrPromise<[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]>;
+  // prettier-ignore
+  public static all<T1, T2, T3, T4, T5, T6, T7, T8, T9>(values: readonly [ValueOrPromise<T1>, ValueOrPromise<T2>, ValueOrPromise<T3>, ValueOrPromise<T4>, ValueOrPromise<T5>, ValueOrPromise<T6>, ValueOrPromise<T7>, ValueOrPromise<T8>, ValueOrPromise<T9>]): ValueOrPromise<[T1, T2, T3, T4, T5, T6, T7, T8, T9]>;
+  // prettier-ignore
+  public static all<T1, T2, T3, T4, T5, T6, T7, T8>(values: readonly [ValueOrPromise<T1>, ValueOrPromise<T2>, ValueOrPromise<T3>, ValueOrPromise<T4>, ValueOrPromise<T5>, ValueOrPromise<T6>, ValueOrPromise<T7>, ValueOrPromise<T8>]): ValueOrPromise<[T1, T2, T3, T4, T5, T6, T7, T8]>;
+  // prettier-ignore
+  public static all<T1, T2, T3, T4, T5, T6, T7>(values: readonly [ValueOrPromise<T1>, ValueOrPromise<T2>, ValueOrPromise<T3>, ValueOrPromise<T4>, ValueOrPromise<T5>, ValueOrPromise<T6>, ValueOrPromise<T7>]): ValueOrPromise<[T1, T2, T3, T4, T5, T6, T7]>;
+  // prettier-ignore
+  public static all<T1, T2, T3, T4, T5, T6>(values: readonly [ValueOrPromise<T1>, ValueOrPromise<T2>, ValueOrPromise<T3>, ValueOrPromise<T4>, ValueOrPromise<T5>, ValueOrPromise<T6>]): ValueOrPromise<[T1, T2, T3, T4, T5, T6]>;
+  // prettier-ignore
+  public static all<T1, T2, T3, T4, T5>(values: readonly [ValueOrPromise<T1>, ValueOrPromise<T2>, ValueOrPromise<T3>, ValueOrPromise<T4>, ValueOrPromise<T5>]): ValueOrPromise<[T1, T2, T3, T4, T5]>;
+  // prettier-ignore
+  public static all<T1, T2, T3, T4>(values: readonly [ValueOrPromise<T1>, ValueOrPromise<T2>, ValueOrPromise<T3>, ValueOrPromise<T4>]): ValueOrPromise<[T1, T2, T3, T4]>;
+  // prettier-ignore
+  public static all<T1, T2, T3>(values: readonly [ValueOrPromise<T1>, ValueOrPromise<T2>, ValueOrPromise<T3>]): ValueOrPromise<[T1, T2, T3]>;
+  // prettier-ignore
+  public static all<T1, T2>(values: readonly [ValueOrPromise<T1>, ValueOrPromise<T2>]): ValueOrPromise<[T1, T2]>;
   public static all<T>(
     valueOrPromises: ReadonlyArray<ValueOrPromise<T>>
-  ): ValueOrPromise<Array<T | null | undefined>> {
-    const values: Array<T | null | undefined> = [];
+  ): ValueOrPromise<Array<T>> {
+    const values: Array<T> = [];
 
     for (let i = 0; i < valueOrPromises.length; i++) {
       const valueOrPromise = valueOrPromises[i];

--- a/src/ValueOrPromise.ts
+++ b/src/ValueOrPromise.ts
@@ -92,7 +92,7 @@ export class ValueOrPromise<T> {
     return this.then(undefined, onRejected);
   }
 
-  public resolve(): T | Promise<T> | undefined | null {
+  public resolve(): T | Promise<T> {
     const state = this.state;
 
     if (state.status === 'pending') {


### PR DESCRIPTION
It seems like appending `null | undefined` to `T` is unnecessary. Instead, if the value can be a maybe, the `null | undefined` should be provided as part of the generic parameter `T`